### PR TITLE
docs : MongoDB University 웨비나 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,11 @@
   - 주최: 네이버 클라우드 
   - 일시: 02. 25(목) 10:00 ~ 12:00
   - 신청: [Link](https://register.gotowebinar.com/register/5855025174790246671)
+- __MongoDB University Webinar__
+  - 분류: `웨비나`, `교육`
+  - 주최: MongoDB university korea
+  - 일시: 02. 25(목) 14:00 ~ 15:00
+  - 신청: [Link](https://mongodbkoreauniveristycertific.splashthat.com/)
 - __리얼리눅스 무료세미나: 라즈베리파이로 코딩하기__
   - 분류: `무료교육`, `리눅스`
   - 주최: 리얼리눅스 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,11 @@
   - 주최: 네이버 클라우드 
   - 일시: 02. 25(목) 10:00 ~ 12:00
   - 신청: [Link](https://register.gotowebinar.com/register/5855025174790246671)
+- __Best of GitHub Universe Live - KR__
+  - 분류: `웨비나`
+  - 주최: GitHub 총판 단군소프트
+  - 일시: 02. 25(목) 13:00 ~ 15:00
+  - 신청: [Link](https://resources.github.com/webcasts/kr-Universe-Live/)
 - __MongoDB University Webinar__
   - 분류: `웨비나`, `교육`
   - 주최: MongoDB university korea


### PR DESCRIPTION
MongoDB University 웨비나

주최 : MongoDB University Korea
일시 : 02. 25(목) 14:00 ~ 15:00
내용
- MongoDB University 소개
- 샘플 예제 60문제 풀이
- 스터디 가이드
혜택
- 기간: ​~2021년 3월말까지
- 혜택(1):​ 기간 내에 시험을 응시하신 모든분들께 ​‘응시료 50% 할인​’
- 혜택(2)​: 기간 내에 시험을 응시&합격하신 모든분들께 ‘​응시료 100% 반환’+ 몽고디비 기프트박스​’