### PR TITLE
fix: 스프린트 서울 url 오류 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@
 
 | 이름 | 링크 |
 |------------|-----------|
-| 스프린트 서울 | [www.sprintseoul.org](https://www.sprintseoul.org/), [채팅방](https://gitter.im/sprintseoul/community) |
+| 스프린트 서울 | [sprintseoul.org](https://sprintseoul.org/), [채팅방](https://gitter.im/sprintseoul/community) |
 | DevOps Korea | [facebook](https://www.facebook.com/groups/TeAnE/) |
 | Serverless Korea | [event-us](https://event-us.kr/bsBxCcQJioWM/event) |
 | Google Developers Experts | [developers.google.com](https://developers.google.com/community/experts) |


### PR DESCRIPTION
url 오류를 수정했습니다.
<img width="1440" alt="스크린샷 2021-10-03 오후 12 25 35" src="https://user-images.githubusercontent.com/19399338/135738285-6fb9bb86-905a-483c-ae4f-4db7f79189da.png">
