### PR TITLE
sudo : CTO’s Tech Talk 2022 행사 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@
 
 <br />
 
+## 22년 01월
+- __[sudo : CTO’s Tech Talk 2022](https://fastcampus.co.kr/devcon_sudo22?utm_source=media&utm_medium=viral&utm_campaign=prd%5E211206%5E17163&utm_content=teacher%5Elgw)__
+  - 분류: `컨퍼런스`, `유료`
+  - 주최: 패스트캠퍼스
+  - 일시: 01. 15(토) ~ 01. 16(일) 13:00 ~ 18:20
+
+<br />
+
 ---------------
 
 <br />


### PR DESCRIPTION
22년 1월의 섹션을 추가했습니다. 형식이 잘 맞는지 모르겠네요 🥲

패스트캠퍼스의 sudo : CTO’s Tech Talk 2022행사를 추가했습니다.