### PR TITLE
[FIX] 잘못된 GDSC 모집 링크 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-49-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 <div align=center>
 
@@ -11,7 +12,7 @@
 <br />
 <br />
 
-<!-- 
+<!--
 ## 📣 Dev Event Mail
 
 <div align=center>
@@ -95,7 +96,7 @@
     </a>
   </td>
 </tr>
-</table>  
+</table>
 
 > 배너 클릭시 연관 링크로 이동합니다.
 
@@ -114,108 +115,108 @@
 <br />
 
 ## 22년 04월
-- __[AI 아카데미 3기 풀스택 교육](https://www.deepbrainai.io/ko/academy)__
+
+- **[AI 아카데미 3기 풀스택 교육](https://www.deepbrainai.io/ko/academy)**
   - 분류: `교육`, `AI`
   - 주최: 딥브레인 AI
   - 모집: 03. 22(화) ~ 04. 11(월)
-  
-- __[구름 K-Digital Training 전액 국비 지원 교육 과정 모집](https://kdt.goorm.io/)__
+- **[구름 K-Digital Training 전액 국비 지원 교육 과정 모집](https://kdt.goorm.io/)**
   - 분류: `교육`, `AI`, `쿠버네티스`
   - 주최: 구름
   - 일시: 03. 11(금) ~ 04. 12(화)
-- __[Luniverse Web 3.0 for Green Universe](https://luniverse.io/2022/03/29/luniverse-web3-0-for-green-universe/)__
+- **[Luniverse Web 3.0 for Green Universe](https://luniverse.io/2022/03/29/luniverse-web3-0-for-green-universe/)**
   - 분류: `웨비나`, `NFT`
   - 주최: 람다256
   - 일시: 04. 12(화)
-- __[네이버클라우드 대구 세미나](https://festa.io/events/2165)__
+- **[네이버클라우드 대구 세미나](https://festa.io/events/2165)**
   - 분류: `오프라인`, `클라우드`
   - 주최: 네이버 클라우드 플랫폼
   - 일시: 04. 13(수) 10:00 ~ 14:00
-- __[전자정부 표준프레임워크 4.0 소개](https://open.egovframe.org/oc/support/noticeItem.do?nttId=20040)__
+- **[전자정부 표준프레임워크 4.0 소개](https://open.egovframe.org/oc/support/noticeItem.do?nttId=20040)**
   - 분류: `온라인`
   - 주최: OPDC
   - 일시: 04. 13(수) 19:00
-- __[2022년 ICT콤플렉스 세미나 제2회](http://www.ictcoc.kr/04_com_n/com02_view.asp?idx=545&page=1&params=)__
+- **[2022년 ICT콤플렉스 세미나 제2회](http://www.ictcoc.kr/04_com_n/com02_view.asp?idx=545&page=1&params=)**
   - 분류: `오프라인`, `메타버스`
   - 주최: ICT COC
   - 일시: 04. 13(수) 16:00
-- __[2022 오픈소스 컨트리뷰션 아카데미: 멘토 모집](https://www.oss.kr/notice/show/344f792e-e09f-46c2-b88f-a9273ea54b34)__
+- **[2022 오픈소스 컨트리뷰션 아카데미: 멘토 모집](https://www.oss.kr/notice/show/344f792e-e09f-46c2-b88f-a9273ea54b34)**
   - 분류: `경진대회`, `멘토링`
   - 주최: 과학기술정보통신부
   - 접수: 03. 04(금) ~ 04. 14(목)
-- __[2022 인디크래프트](https://www.onoffmix.com/event/253249)__
+- **[2022 인디크래프트](https://www.onoffmix.com/event/253249)**
   - 분류: `경진대회`
   - 주최: 성남시
   - 일시: 03. 24(목) ~ 04. 14(목)
-- __[LINE 서버 개발자들이 말한다! Armeria 아직도 안써요?](https://feedback.line.me/enquete/public/16066-pDXMVqbH)__
+- **[LINE 서버 개발자들이 말한다! Armeria 아직도 안써요?](https://feedback.line.me/enquete/public/16066-pDXMVqbH)**
   - 분류: `경진대회`
   - 주최: LINE
   - 일시: 04. 14(목) 16:00 ~ 18:00
-- __[제 20대 대선 후보 정책•공약 시각화 경진대회](https://dacon.io/competitions/official/235891/overview/prize)__
+- **[제 20대 대선 후보 정책•공약 시각화 경진대회](https://dacon.io/competitions/official/235891/overview/prize)**
   - 분류: `경진대회`, `데이터`
   - 주최: DACON
   - 일시: 03. 07(수) ~ 04. 15(금)
-- __[2022 국제인공지능대전](https://onoffmix.com/event/249605)__
+- **[2022 국제인공지능대전](https://onoffmix.com/event/249605)**
   - 분류: `컨퍼런스`, `AI`
   - 주최: 한국인공지능협회
   - 일시: 04. 13(수) ~ 04. 15(금)
-- __[2022 우아한스터디 참여 신청](https://event.stibee.com/v2/click/NDg3ODgvOTMzMDE5LzQzODk2Lw/aHR0cHM6Ly9wdWZmeS1zdGljay1mYTEubm90aW9uLnNpdGUvMjAyMi1jYTVmNDNmYzI1OWQ0NDZkODFmMzc2MjU2ZDE4Yjk5Yg)__
+- **[2022 우아한스터디 참여 신청](https://event.stibee.com/v2/click/NDg3ODgvOTMzMDE5LzQzODk2Lw/aHR0cHM6Ly9wdWZmeS1zdGljay1mYTEubm90aW9uLnNpdGUvMjAyMi1jYTVmNDNmYzI1OWQ0NDZkODFmMzc2MjU2ZDE4Yjk5Yg)**
   - 분류: `스터디`
   - 주최: 우아한형제들
   - 신청: 04. 04(월) ~ 04. 17(일)
-- __[KT 무선네트워크 설계 및 운용](https://www.catch.co.kr/CatchClass/Live/View/5082)__
+- **[KT 무선네트워크 설계 및 운용](https://www.catch.co.kr/CatchClass/Live/View/5082)**
   - 분류: `웨비나`, `멘토링`
   - 주최: 캐치
   - 일시: 04. 20(수) 20:00 ~ 21:30
-- __[4월 원티드살롱 #연봉협상](https://www.wanted.co.kr/events/wantedsalon220420)__
+- **[4월 원티드살롱 #연봉협상](https://www.wanted.co.kr/events/wantedsalon220420)**
   - 분류: `웨비나`
   - 주최: 원티드
   - 일시: 04. 20(수) 19:30 ~ 21:30
-- __[Microsoft Everywhere 2022](https://mktoevents.com/Microsoft+Event/325223/157-GQE-382)__
+- **[Microsoft Everywhere 2022](https://mktoevents.com/Microsoft+Event/325223/157-GQE-382)**
   - 분류: `컨퍼런스`, `보안`
   - 주최: 마이크로소프트
   - 일시: 04. 20(수) 14:00 ~ 15:00
-- __[NVIDIA AI 개발자 밋업 - TensorRT/Triton](https://festa.io/events/2205)__
+- **[NVIDIA AI 개발자 밋업 - TensorRT/Triton](https://festa.io/events/2205)**
   - 분류: `웨비나`, `AI`
   - 주최: NVIDIA
   - 일시: 04. 21(목) 14:00 ~ 16:00
-- __[Web3 세상의 데이터 네트워크와 블록체인 서비스 인프라 현황](https://devocean.sk.com/events/view.do?id=115)__
+- **[Web3 세상의 데이터 네트워크와 블록체인 서비스 인프라 현황](https://devocean.sk.com/events/view.do?id=115)**
   - 분류: `웨비나`, `AI`
   - 주최: DEVOCEAN
   - 일시: 04. 21(목) 15:00 ~ 17:00
-- __[협업툴 WORK 5.0 팀 목표와 워크레시피](https://festa.io/events/2153)__
+- **[협업툴 WORK 5.0 팀 목표와 워크레시피](https://festa.io/events/2153)**
   - 분류: `일반`
   - 주최: 플로우
   - 일시: 04. 21(목) 15:00 ~ 16:00
-- __[XR, 메타버스 분야 글로벌 네트워크의 시작 - AWE Nite Seoul 1](https://festa.io/events/2198)__
+- **[XR, 메타버스 분야 글로벌 네트워크의 시작 - AWE Nite Seoul 1](https://festa.io/events/2198)**
   - 분류: `메타버스`
   - 주최: AWE Nite Seoul
   - 일시: 04. 21(목) 09:30 ~ 21:30
-- __[LG Solution Day 손쉬운 클라우드/MSA 변환](https://www.lgcnswithyou.com/login/register/SolutionDay202204?ibch=itboard)__
+- **[LG Solution Day 손쉬운 클라우드/MSA 변환](https://www.lgcnswithyou.com/login/register/SolutionDay202204?ibch=itboard)**
   - 분류: `웨비나`, `MSA`
   - 주최: LG
   - 일시: 04. 21(목)
-- __[세계 보안 엑스포 2022](https://www.seconexpo.com/kor/main.asp)__
+- **[세계 보안 엑스포 2022](https://www.seconexpo.com/kor/main.asp)**
   - 분류: `일반`
   - 주최: 인포마마켓한국
   - 일시: 04. 20(수) ~ 04. 22(금)
-- __[2022 휴먼이해 인공지능 논문경진대회](https://aifactory.space/competition/detail/2006)__
+- **[2022 휴먼이해 인공지능 논문경진대회](https://aifactory.space/competition/detail/2006)**
   - 분류: `일반`
   - 주최: 에트리
   - 일시: 03. 16(수) ~ 04. 22(금)
-- __[GDG Korea WebTech Online 이력서 멘토링 2022](https://festa.io/events/2164)__
+- **[GDG Korea WebTech Online 이력서 멘토링 2022](https://festa.io/events/2164)**
   - 분류: `웨비나`, `멘토링`
   - 주최: GDG Korea WebTech
   - 일시: 04. 23(토) 14:00 ~ 17:00
-- __[NVIDIA Jetson 개발자 밋업 - Robotics](https://festa.io/events/2206)__
+- **[NVIDIA Jetson 개발자 밋업 - Robotics](https://festa.io/events/2206)**
   - 분류: `웨비나`, `로봇`
   - 주최: NVIDIA
   - 일시: 04. 26(화) 14:00 ~ 17:00
-- __[제 1회 정보검색사례연구회 소모임](https://festa.io/events/2191)__
+- **[제 1회 정보검색사례연구회 소모임](https://festa.io/events/2191)**
   - 분류: `모임`, `검색`
   - 주최: 한국정보검색사례연구회
   - 일시: 04. 28(목) 19:30 ~ 21:30
-- __[AWSKRUG #architecture 소모임](https://www.meetup.com/awskrug/events/284946336/)__
+- **[AWSKRUG #architecture 소모임](https://www.meetup.com/awskrug/events/284946336/)**
   - 분류: `모임`, `AWS`
   - 주최: AWSKRUG
   - 일시: 04. 28(목) 19:30 ~ 21:30
@@ -223,24 +224,26 @@
 <br />
 
 ## 22년 5월
-- __[제4회 오픈 인프라 개발 경진 대회 (OIDC 2022)](http://www.oidc.co.kr/)__
+
+- **[제4회 오픈 인프라 개발 경진 대회 (OIDC 2022)](http://www.oidc.co.kr/)**
+
   - 분류: `클라우드`, `경진대회`
   - 주최: 맨텍
   - 일시: 04. 04(월) ~ 05. 09(월)
 
-- __[Unity Wave 2022 1차 세션](http://www.unitysquare.co.kr/growwith/unitywave )__
+- **[Unity Wave 2022 1차 세션](http://www.unitysquare.co.kr/growwith/unitywave)**
   - 분류: `웨비나`, `유니티`
   - 주최: 유니티
   - 일시: 05. 09(월) ~ 05. 13(금)
-- __[AWS SUMMIT KOREA](https://aws.amazon.com/ko/events/summits/korea/)__
+- **[AWS SUMMIT KOREA](https://aws.amazon.com/ko/events/summits/korea/)**
   - 분류: `웨비나`, `클라우드`
   - 주최: AWS
   - 일시: 05. 10(화) ~ 05. 11(수)
-- __[코로나시대의 안드로이드 개발자들](https://event-us.kr/ted/event/43225)__
+- **[코로나시대의 안드로이드 개발자들](https://event-us.kr/ted/event/43225)**
   - 분류: `컨퍼런스`, `안드로이드`
   - 주최: AWS
   - 접수: 04. 04(월) ~ 05. 12(목)
-- __[Google Developer Student Club(GDSC) Lead 모집](https://event-us.kr/ted/event/43225)__
+- **[Google Developer Student Club(GDSC) Lead 모집](https://developers-kr.googleblog.com/2022/04/google-developer-student-club-2022-lead_01421805175.html)**
   - 분류: `모임`
   - 주최: Google Developers Korea
   - 접수: 04. 01(금) ~ 05. 31(화)
@@ -248,24 +251,26 @@
 <br />
 
 ## 22년 06월
-- __[애플 WWDC 2022](https://developer.apple.com/wwdc22)__
+
+- **[애플 WWDC 2022](https://developer.apple.com/wwdc22)**
+
   - 분류: `컨퍼런스`
   - 주최: Apple
   - 일시: 06. 06(월) ~ 06. 10(금)
 
-- __[nexon developers conference 22](https://ndc.nexon.com/main)__
+- **[nexon developers conference 22](https://ndc.nexon.com/main)**
   - 분류: `컨퍼런스`
   - 주최: 넥슨
   - 일시: 06. 07(화) ~ 06. 10(금)
-- __[2022 Azure Virtual Hackathon](https://aifactory.space/competition/detail/2005)__
+- **[2022 Azure Virtual Hackathon](https://aifactory.space/competition/detail/2005)**
   - 분류: `대회`, `DevOps`, `AI`, `클라우드`
   - 주최: 마이크로소프트
   - 일시: 03. 24(목) ~ 06. 10(금)
-- __[2022 휴먼이해 인공지능 논문경진대회](https://aifactory.space/competition/detail/2006)__
+- **[2022 휴먼이해 인공지능 논문경진대회](https://aifactory.space/competition/detail/2006)**
   - 분류: `대회`, `인공지능`
   - 주최: 에트리
   - 일시: 03. 16(토) ~ 06. 30(일)
-- __[메타버스엑스포 2022](https://metavexpo.com/visitor/registration/)__
+- **[메타버스엑스포 2022](https://metavexpo.com/visitor/registration/)**
   - 분류: `오프라인`, `메타버스`
   - 주최: (주)메쎼이상
   - 일시: 06. 15(수) ~ 06. 17(금)
@@ -273,38 +278,38 @@
 <br />
 
 ## 22년 07월
-- __[2022 전자정부표준프레임워크 컨트리뷰션](https://www.egovframe.go.kr/home/ntt/nttRead.do?pagerOffset=0&searchKey=&searchValue=&menuNo=74&bbsId=6&nttId=1849)__
+
+- **[2022 전자정부표준프레임워크 컨트리뷰션](https://www.egovframe.go.kr/home/ntt/nttRead.do?pagerOffset=0&searchKey=&searchValue=&menuNo=74&bbsId=6&nttId=1849)**
   - 분류: `대회`, `인공지능`
   - 주최: 행정안전부
   - 일시: 03. 28(월) ~ 07. 31(일)
 
-
----------------
+---
 
 <br />
 
 ## 개발자 동아리
 
-| 이름 | 활동 | 링크 |
-|------------|---------|-----------|
-| DDD | 개발자와 디자이너가 함께하는 사이드 프로젝트 | [facebook](https://www.facebook.com/dddstudy/), [Notion](https://www.notion.so/dddset/DDD-7b73ca41b67c4658b292a4662581ee01)  |
-| 한이음 |대학생 멘티와 지도교수, 기업전문가 ICT멘토가 팀을 이루어 실무 프로젝트를 수행 |[www.hanium.or.kr](https://www.hanium.or.kr/portal/hanium/businessOverview.do) |  
-| 넥스터즈 | 개발자와 디자이너 연합 동아리 | [teamnexters.com](http://teamnexters.com/) |
-| YAPP | 대학생 연합 기업형 IT 동아리 | [yapp.co.kr](http://yapp.co.kr/) |
-| Mash-Up | 성장의 즐거움을 아는 친구들 | [mash-up.kr](https://www.mash-up.kr/), [facebook](https://www.facebook.com/mashupgroup/) |
-| AUSG | AWS 대학생 그룹 | [Notion](https://www.notion.so/ausg/AUSG-AWS-f587ae7e146f4c37a313170e1ba603e7/) |
-| D&D | 서울거주 현직자들의 기술공유와 프로젝트를 진행하는 비영리단체 | [dnd.ac](https://dnd.ac/) |
-| SOPT | 대학생 연합 IT벤처 창업 동아리 | [sopt.org](http://sopt.org/wp/), [facebook](https://www.facebook.com/clubsopt) |
-| 멋쟁이사자처럼 | 대학생 연합 동아리 | [likelion.net](https://likelion.net/), [facebook](https://www.facebook.com/likelion.net/) |
-| Google Developer Student <br /> Clubs Korea | Google Developers 에서 후원하는 대학생 개발자 동아리 | [DSC](https://developers.google.com/community/dsc), [DSC Korea](https://sites.google.com/view/dsckr/home), [facebook](https://www.facebook.com/dsckorea) |
-| 디프만 | 디자이너와 프로그래머의 만남 | [depromeet.com](https://www.depromeet.com/) |
-| 프로그라피 | 세상에 필요한 IT서비스를 만드는 모임 | [공식 홈페이지](http://prography.org/), [facebook](https://www.facebook.com/thePrography/)|
-| CEOS | 신촌 연합 IT 창업 동아리 | [공식 홈페이지](https://www.ceos.or.kr/) |
-| Central MakeUs Challenge(CMC) | 수익형 앱 런칭 동아리 | [공식 홈페이지](https://makeus.in/) [instagram](https://www.instagram.com/makeus_challenge/) |
-| University MakeUs Challenge(UMC) | 대학교 연합 앱런칭 동아리 | [1기 모집 노션](https://makeus-challenge.notion.site/University-MakeUs-Challenge-UMC-3a1b2a30fdd94f428cdbd5f91bdf0a5c) |
-| UPF | 프로젝트 완성, 고도화를 위한 팀 부스팅 프로그램 | [Notion](https://unit.center/upf), [facebook](https://www.facebook.com/unit.center) |
-| Central MakeUs Challenge | - | [공식 홈페이지](https://makeus.in/) |
-| 힙한 주니어들의 비밀 | - | [공식 홈페이지](https://litt.ly/hipjubie)
+| 이름                                        | 활동                                                                          | 링크                                                                                                                                                     |
+| ------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| DDD                                         | 개발자와 디자이너가 함께하는 사이드 프로젝트                                  | [facebook](https://www.facebook.com/dddstudy/), [Notion](https://www.notion.so/dddset/DDD-7b73ca41b67c4658b292a4662581ee01)                              |
+| 한이음                                      | 대학생 멘티와 지도교수, 기업전문가 ICT멘토가 팀을 이루어 실무 프로젝트를 수행 | [www.hanium.or.kr](https://www.hanium.or.kr/portal/hanium/businessOverview.do)                                                                           |
+| 넥스터즈                                    | 개발자와 디자이너 연합 동아리                                                 | [teamnexters.com](http://teamnexters.com/)                                                                                                               |
+| YAPP                                        | 대학생 연합 기업형 IT 동아리                                                  | [yapp.co.kr](http://yapp.co.kr/)                                                                                                                         |
+| Mash-Up                                     | 성장의 즐거움을 아는 친구들                                                   | [mash-up.kr](https://www.mash-up.kr/), [facebook](https://www.facebook.com/mashupgroup/)                                                                 |
+| AUSG                                        | AWS 대학생 그룹                                                               | [Notion](https://www.notion.so/ausg/AUSG-AWS-f587ae7e146f4c37a313170e1ba603e7/)                                                                          |
+| D&D                                         | 서울거주 현직자들의 기술공유와 프로젝트를 진행하는 비영리단체                 | [dnd.ac](https://dnd.ac/)                                                                                                                                |
+| SOPT                                        | 대학생 연합 IT벤처 창업 동아리                                                | [sopt.org](http://sopt.org/wp/), [facebook](https://www.facebook.com/clubsopt)                                                                           |
+| 멋쟁이사자처럼                              | 대학생 연합 동아리                                                            | [likelion.net](https://likelion.net/), [facebook](https://www.facebook.com/likelion.net/)                                                                |
+| Google Developer Student <br /> Clubs Korea | Google Developers 에서 후원하는 대학생 개발자 동아리                          | [DSC](https://developers.google.com/community/dsc), [DSC Korea](https://sites.google.com/view/dsckr/home), [facebook](https://www.facebook.com/dsckorea) |
+| 디프만                                      | 디자이너와 프로그래머의 만남                                                  | [depromeet.com](https://www.depromeet.com/)                                                                                                              |
+| 프로그라피                                  | 세상에 필요한 IT서비스를 만드는 모임                                          | [공식 홈페이지](http://prography.org/), [facebook](https://www.facebook.com/thePrography/)                                                               |
+| CEOS                                        | 신촌 연합 IT 창업 동아리                                                      | [공식 홈페이지](https://www.ceos.or.kr/)                                                                                                                 |
+| Central MakeUs Challenge(CMC)               | 수익형 앱 런칭 동아리                                                         | [공식 홈페이지](https://makeus.in/) [instagram](https://www.instagram.com/makeus_challenge/)                                                             |
+| University MakeUs Challenge(UMC)            | 대학교 연합 앱런칭 동아리                                                     | [1기 모집 노션](https://makeus-challenge.notion.site/University-MakeUs-Challenge-UMC-3a1b2a30fdd94f428cdbd5f91bdf0a5c)                                   |
+| UPF                                         | 프로젝트 완성, 고도화를 위한 팀 부스팅 프로그램                               | [Notion](https://unit.center/upf), [facebook](https://www.facebook.com/unit.center)                                                                      |
+| Central MakeUs Challenge                    | -                                                                             | [공식 홈페이지](https://makeus.in/)                                                                                                                      |
+| 힙한 주니어들의 비밀                        | -                                                                             | [공식 홈페이지](https://litt.ly/hipjubie)                                                                                                                |
 
 <br />
 
@@ -314,62 +319,62 @@
 
 ## 개발 교육
 
-| 이름 | 링크 |
-|------------|-----------|
-| 양재동 코드랩 | [Homepage](https://www.codelabs.kr/), [Youtube](https://www.youtube.com/channel/UC7SGsu80wfuTyQWo-PKatvg) |
-| 모두의 연구소 | [Homepage](https://modulabs.co.kr/) |
-| CCCR 아카데미 | [Homepage](https://www.cccr-edu.or.kr/main/index.jsp) |
-| 인공지능혁신학교 AIFFEL  | [Homepage](https://aiffel.io/) |
-| 엘리스 | [Homepage](https://elice.io/home) |
-| 라이징 캠프 | [Homepage](https://risingcamp.com/), [Youtube](https://www.youtube.com/channel/UCkxTr_WrzUBcYeeAfZIQQlA/videos) |
-| 알고리즘 캠프 | [Homepage](https://algorithmcamp.oopy.io/) |
+| 이름                    | 링크                                                                                                            |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------- |
+| 양재동 코드랩           | [Homepage](https://www.codelabs.kr/), [Youtube](https://www.youtube.com/channel/UC7SGsu80wfuTyQWo-PKatvg)       |
+| 모두의 연구소           | [Homepage](https://modulabs.co.kr/)                                                                             |
+| CCCR 아카데미           | [Homepage](https://www.cccr-edu.or.kr/main/index.jsp)                                                           |
+| 인공지능혁신학교 AIFFEL | [Homepage](https://aiffel.io/)                                                                                  |
+| 엘리스                  | [Homepage](https://elice.io/home)                                                                               |
+| 라이징 캠프             | [Homepage](https://risingcamp.com/), [Youtube](https://www.youtube.com/channel/UCkxTr_WrzUBcYeeAfZIQQlA/videos) |
+| 알고리즘 캠프           | [Homepage](https://algorithmcamp.oopy.io/)                                                                      |
 
 <br />
 
 ## 개발자 모임
 
-| 이름 | 링크 |
-|------------|-----------|
-| 스프린트 서울 | [sprintseoul.org](https://sprintseoul.org/), [채팅방](https://gitter.im/sprintseoul/community) |
-| DevOps Korea | [facebook](https://www.facebook.com/groups/TeAnE/) |
-| Serverless Korea | [event-us](https://event-us.kr/bsBxCcQJioWM/event) |
-| Google Developers Experts | [developers.google.com](https://developers.google.com/community/experts) |
-| GDG Golang korea | [facebook](https://www.facebook.com/gdggo/) |
-| Data Scientist Meetup in Seoul |[meetup](https://www.meetup.com/ko-KR/Data-Scientist-Meetup-in-Seoul/) |
-| IT인프라 엔지니어 그룹 | [facebook](https://www.facebook.com/groups/InfraEngineer/) |
-| GDG DevFest Seoul | [facebook](https://www.facebook.com/devfest.seoul.2019/) |
-| OSS 개발자 포럼 | [facebook](https://www.facebook.com/groups/ossdevforum) |
-| 오픈 인프라 | [oidc.co.kr](http://oidc.co.kr/) |
-| CNCG Seoul | [cncg-kr.net](https://cncg-kr.net/) |
-| SK 개발자 모임 | [thub.sk.com](https://thub.sk.com/) |
-| FinOps Korea | [facebook](https://www.facebook.com/groups/finops.community1) |
-| 스사모(한국 스파크 사용자 모임) | [facebook](https://www.facebook.com/groups/sparkkoreauser/) |
-| React Korea | [facebook](https://www.facebook.com/groups/react.ko/) |
-| Vuejs Korea | [facebook](https://vuejs-kr.github.io/) |
-| Django Girls Seoul | [djangogirls.org](https://djangogirls.org/seoul/) |
-| OSXDev.org | [facebook](https://www.facebook.com/groups/osxdevorg/) |
-| GDG Korea WebTech | [facebook](https://www.facebook.com/groups/webTechKR/) |
-| KSUG - 한국 스프링 사용자 모임 | [facebook](https://www.ksug.org/) |
-| devocean | [devocean.sk.com](https://devocean.sk.com/)
-| OpenStack Korea 커뮤니티 | [facebook](https://www.facebook.com/groups/openstack.kr) |
-| Ceph 한국 커뮤니티 | [facebook](https://www.facebook.com/groups/620899444961207) |
-| Open Compute Project 한국 커뮤니티 | [facebook](https://www.facebook.com/groups/ocpkorea/) |
-| 표준프레임워크 오픈커뮤니티 | [open.egovframe.org](https://open.egovframe.org/) |
-| 게임 서버 개발자 모임 | [facebook](https://www.facebook.com/groups/207844736374114/) |
-| Kubernetes Korea | [facebook](https://www.facebook.com/groups/k8skr/) |
-| KubernPostgreSQL Korea | [facebook](https://www.facebook.com/groups/postgres.kr), [github](https://github.com/PostgreSQL-Korea) |
-| 한국 리눅스 사용자 그룹 | [facebook](https://www.facebook.com/groups/korelnxuser/), [homepage](http://www.lug.or.kr/home/) |
-| Korea Elasticsearch User Group | [facebook](https://www.facebook.com/groups/elasticsearch.kr/), [github](https://github.com/eskrug) |
-| Kotlin Korea | [facebook](https://www.facebook.com/groups/kotlinkr/), [homepage](http://kotlin.kr/) |
-| 구글 Flutter 한국 사용자 그룹 | [facebook](https://www.facebook.com/groups/flutterkorea/) |
-| React Korea | [facebook](https://www.facebook.com/groups/react.ko/) |
-| Kaggle Korea | [facebook](https://www.facebook.com/groups/KaggleKoreaOpenGroup/) |
-| 파이토치 한국 사용자 모임 | [homepage](https://pytorch.kr/), [facebook](https://www.facebook.com/groups/PyTorchKR/) |
-| Girls In Tech Korea | [homepage](https://korea.girlsintech.org/) |
-| OKKY (Java,Spring) | [homepage](https://okky.kr/) |
-| 남궁성의 코드초보 스터디 (Java,C) | [homepage](https://cafe.naver.com/javachobostudy) |
-| 우분투 한국 커뮤니티 | [homepage](https://ubuntu-kr.org), [facebook](https://www.facebook.com/groups/ubuntu.ko) |
-| 안드로이드개발 | [facebook](https://www.facebook.com/groups/androidcode/) |
+| 이름                               | 링크                                                                                                   |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| 스프린트 서울                      | [sprintseoul.org](https://sprintseoul.org/), [채팅방](https://gitter.im/sprintseoul/community)         |
+| DevOps Korea                       | [facebook](https://www.facebook.com/groups/TeAnE/)                                                     |
+| Serverless Korea                   | [event-us](https://event-us.kr/bsBxCcQJioWM/event)                                                     |
+| Google Developers Experts          | [developers.google.com](https://developers.google.com/community/experts)                               |
+| GDG Golang korea                   | [facebook](https://www.facebook.com/gdggo/)                                                            |
+| Data Scientist Meetup in Seoul     | [meetup](https://www.meetup.com/ko-KR/Data-Scientist-Meetup-in-Seoul/)                                 |
+| IT인프라 엔지니어 그룹             | [facebook](https://www.facebook.com/groups/InfraEngineer/)                                             |
+| GDG DevFest Seoul                  | [facebook](https://www.facebook.com/devfest.seoul.2019/)                                               |
+| OSS 개발자 포럼                    | [facebook](https://www.facebook.com/groups/ossdevforum)                                                |
+| 오픈 인프라                        | [oidc.co.kr](http://oidc.co.kr/)                                                                       |
+| CNCG Seoul                         | [cncg-kr.net](https://cncg-kr.net/)                                                                    |
+| SK 개발자 모임                     | [thub.sk.com](https://thub.sk.com/)                                                                    |
+| FinOps Korea                       | [facebook](https://www.facebook.com/groups/finops.community1)                                          |
+| 스사모(한국 스파크 사용자 모임)    | [facebook](https://www.facebook.com/groups/sparkkoreauser/)                                            |
+| React Korea                        | [facebook](https://www.facebook.com/groups/react.ko/)                                                  |
+| Vuejs Korea                        | [facebook](https://vuejs-kr.github.io/)                                                                |
+| Django Girls Seoul                 | [djangogirls.org](https://djangogirls.org/seoul/)                                                      |
+| OSXDev.org                         | [facebook](https://www.facebook.com/groups/osxdevorg/)                                                 |
+| GDG Korea WebTech                  | [facebook](https://www.facebook.com/groups/webTechKR/)                                                 |
+| KSUG - 한국 스프링 사용자 모임     | [facebook](https://www.ksug.org/)                                                                      |
+| devocean                           | [devocean.sk.com](https://devocean.sk.com/)                                                            |
+| OpenStack Korea 커뮤니티           | [facebook](https://www.facebook.com/groups/openstack.kr)                                               |
+| Ceph 한국 커뮤니티                 | [facebook](https://www.facebook.com/groups/620899444961207)                                            |
+| Open Compute Project 한국 커뮤니티 | [facebook](https://www.facebook.com/groups/ocpkorea/)                                                  |
+| 표준프레임워크 오픈커뮤니티        | [open.egovframe.org](https://open.egovframe.org/)                                                      |
+| 게임 서버 개발자 모임              | [facebook](https://www.facebook.com/groups/207844736374114/)                                           |
+| Kubernetes Korea                   | [facebook](https://www.facebook.com/groups/k8skr/)                                                     |
+| KubernPostgreSQL Korea             | [facebook](https://www.facebook.com/groups/postgres.kr), [github](https://github.com/PostgreSQL-Korea) |
+| 한국 리눅스 사용자 그룹            | [facebook](https://www.facebook.com/groups/korelnxuser/), [homepage](http://www.lug.or.kr/home/)       |
+| Korea Elasticsearch User Group     | [facebook](https://www.facebook.com/groups/elasticsearch.kr/), [github](https://github.com/eskrug)     |
+| Kotlin Korea                       | [facebook](https://www.facebook.com/groups/kotlinkr/), [homepage](http://kotlin.kr/)                   |
+| 구글 Flutter 한국 사용자 그룹      | [facebook](https://www.facebook.com/groups/flutterkorea/)                                              |
+| React Korea                        | [facebook](https://www.facebook.com/groups/react.ko/)                                                  |
+| Kaggle Korea                       | [facebook](https://www.facebook.com/groups/KaggleKoreaOpenGroup/)                                      |
+| 파이토치 한국 사용자 모임          | [homepage](https://pytorch.kr/), [facebook](https://www.facebook.com/groups/PyTorchKR/)                |
+| Girls In Tech Korea                | [homepage](https://korea.girlsintech.org/)                                                             |
+| OKKY (Java,Spring)                 | [homepage](https://okky.kr/)                                                                           |
+| 남궁성의 코드초보 스터디 (Java,C)  | [homepage](https://cafe.naver.com/javachobostudy)                                                      |
+| 우분투 한국 커뮤니티               | [homepage](https://ubuntu-kr.org), [facebook](https://www.facebook.com/groups/ubuntu.ko)               |
+| 안드로이드개발                     | [facebook](https://www.facebook.com/groups/androidcode/)                                               |
 
 <br />
 
@@ -377,17 +382,17 @@
 
 > 정규적으로 열리는 개발자 행사입니다.
 
-| 이름 | 링크 |
-|------------|-----------|
-| TeamH4C | [facebook](https://www.facebook.com/teamh4c/) |
-| Angel Hack Seoul | [angelhackseoul.kr](https://angelhackseoul.kr/) |
-| Google HashCode | [codingcompetitions.withgoogle.com](https://codingcompetitions.withgoogle.com/hashcode/) |
-| Codeengn | [codeengn.com](https://codeengn.com/conference/) |
-| CTF Time | [ctftime.org](http://ctftime.org/?fbclid=IwAR26fXW5aM0YTfSYOdVE34LJuQZnUQSJry54ORvkB5XZGAbi3_LdC-ACOaU) |
-| 스프링 캠프 | [springcamp.io/2019](https://www.springcamp.io/2019/) |
-| DACON | [dacon.io](https://dacon.io) |
-| FEConf | [feconf.kr](https://feconf.kr/)|
-| JunctionX Seoul | [facebook](https://www.facebook.com/junctionxseoul/)|
+| 이름             | 링크                                                                                                    |
+| ---------------- | ------------------------------------------------------------------------------------------------------- |
+| TeamH4C          | [facebook](https://www.facebook.com/teamh4c/)                                                           |
+| Angel Hack Seoul | [angelhackseoul.kr](https://angelhackseoul.kr/)                                                         |
+| Google HashCode  | [codingcompetitions.withgoogle.com](https://codingcompetitions.withgoogle.com/hashcode/)                |
+| Codeengn         | [codeengn.com](https://codeengn.com/conference/)                                                        |
+| CTF Time         | [ctftime.org](http://ctftime.org/?fbclid=IwAR26fXW5aM0YTfSYOdVE34LJuQZnUQSJry54ORvkB5XZGAbi3_LdC-ACOaU) |
+| 스프링 캠프      | [springcamp.io/2019](https://www.springcamp.io/2019/)                                                   |
+| DACON            | [dacon.io](https://dacon.io)                                                                            |
+| FEConf           | [feconf.kr](https://feconf.kr/)                                                                         |
+| JunctionX Seoul  | [facebook](https://www.facebook.com/junctionxseoul/)                                                    |
 
 <br />
 <br />
@@ -473,10 +478,10 @@
 <br />
 
 Special Thanks to
+
 - [@leedoopal](https://github.com/leedoopal) - Dev Event Web Client
 - [@Limm-jk](https://github.com/Limm-jk) - Dev Event Subscribe
 - [@jisungbin](https://github.com/jisungbin) - Dev Event Android
-
 
 <br />
 <br />


### PR DESCRIPTION
 readme 파일 중
5월
[코로나 시대의 안드로이드 개발자들] 링크와
[Google Developer Student Club(GDSC) Lead 모집] 링크의 중복을 확인하고 수정했습니다.

⬇새로 수정한 링크
https://developers-kr.googleblog.com/2022/04/google-developer-student-club-2022-lead_01421805175.html


+ 수정 과정에서 형식 자동변환으로 인해 __가 **로 변환되었습니다