### PR TITLE
docs: 개발자 동아리 항목 변경사항 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@
 | 넥스터즈 | 개발자와 디자이너 연합 동아리                              | [teamnexters.com](http://teamnexters.com/) |
 | YAPP | 대학생 연합 기업형 IT 동아리                             | [yapp.co.kr](http://yapp.co.kr/) |
 | Mash-Up | 성장의 즐거움을 아는 친구들                               | [mash-up.kr](https://www.mash-up.kr/), [facebook](https://www.facebook.com/mashupgroup/) |
-| AUSG | AWS 대학생 그룹                                    | [Notion](https://www.notion.so/ausg/AUSG-AWS-f587ae7e146f4c37a313170e1ba603e7/) |
+| AUSG | AWS 대학생 그룹                                    | [ausg.me](https://ausg.me/) |
 | D&D | 서울거주 현직자들의 기술공유와 프로젝트를 진행하는 비영리단체             | [dnd.ac](https://dnd.ac/) |
 | SOPT | 대학생 연합 IT벤처 창업 동아리                            | [sopt.org](http://sopt.org/wp/), [facebook](https://www.facebook.com/clubsopt) |
 | 멋쟁이사자처럼 | 대학생 연합 동아리                                    | [likelion.net](https://likelion.net/), [facebook](https://www.facebook.com/likelion.net/) |

--- a/README.md
+++ b/README.md
@@ -274,7 +274,6 @@
 | University MakeUs Challenge(UMC) | 대학교 연합 앱런칭 동아리                                | [1기 모집 노션](https://makeus-challenge.notion.site/University-MakeUs-Challenge-UMC-3a1b2a30fdd94f428cdbd5f91bdf0a5c) |
 | UPF | 프로젝트 완성, 고도화를 위한 팀 부스팅 프로그램                   | [Notion](https://unit.center/upf), [facebook](https://www.facebook.com/unit.center) |
 | Central MakeUs Challenge | -                                             | [공식 홈페이지](https://makeus.in/) |
-| 힙한 주니어들의 비밀 | -                                             | [공식 홈페이지](https://litt.ly/hipjubie)
 
 <br />
 


### PR DESCRIPTION
## 변경사항

- AUSG의 노션 링크(4기 지원 기간 이후 변경사항 없는 것으로 보임)를 현재 운영 중인 [웹사이트](https://ausg.me/)로 변경
- 현재 운영되지 않는 동아리를 동아리 목록에서 제거

## Commits

- 1097f41 docs: AUSG 링크 현재 운영중인 홈페이지 링크로 변경
- ee862f5 docs: 운영되지 않는 동아리 목록에서 제거

---

관심있게 지켜보다 첫 PR보냅니다😆