### PR TITLE
docs:`소주콘 Shot 1 : 진로 빨간 뚜껑` 행사일시 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@
 - __[소주콘 Shot 1 : 진로 빨간 뚜껑](https://festa.io/events/2433)__
   - 분류: `온라인`
   - 주최: 소문난 주니어 콘퍼런스
-  - 일시: 07. 15(금) 16:00 ~ 17:00
+  - 일시: 07. 19(화) 19:20 ~ 21:40
 - __[I/O Extended Golang Korea 2022](https://festa.io/events/2360)__
   - 분류: `온라인`, `오프라인`, `Golang` 
   - 주최: Golang Korea


### PR DESCRIPTION
# 변경사항

- **소주콘 Shot 1 : 진로 빨간 뚜껑** 행사의 일시 변경

<img width="290" alt="image" src="https://user-images.githubusercontent.com/39324973/178091076-6d27e085-19f1-489f-89ff-acbdbd2d2669.png">