### PR TITLE
update : 오픈소스SW 라이선스 전문교육 고급과정 2차 링크 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@
 <br />
 
 ## 22년 09월
-- __[2022 오픈소스SW 라이선스 전문교육 고급과정 2차](https://www.olis.or.kr/consulting/openswStudyDetail.do?seq=442)__
+- __[2022 오픈소스SW 라이선스 전문교육 고급과정 2차](https://www.olis.or.kr/consulting/openswStudyDetail.do?seq=444)__
   - 분류: `오프라인`, `교육`, `오픈소스`
   - 주최: 문화체육관광부
   - 접수: 07. 27(수) ~ 09. 01(목)


### PR DESCRIPTION
- [2022 오픈소스SW 라이선스 전문교육 일반과정 1차](https://www.olis.or.kr/consulting/openswStudyDetail.do?seq=442)와 링크가 동일하여 `고급과정` 신청 링크에 맞게 수정했습니다.

---

항상 좋은 정보 공유해주셔서 감사합니다.