### PR TITLE
Remove Google Hash Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,6 @@
 |------------|-----------|
 | TeamH4C | [facebook](https://www.facebook.com/teamh4c/) |
 | Angel Hack Seoul | [angelhackseoul.kr](https://angelhackseoul.kr/) |
-| Google HashCode | [codingcompetitions.withgoogle.com](https://codingcompetitions.withgoogle.com/hashcode/) |
 | Codeengn | [codeengn.com](https://codeengn.com/conference/) |
 | CTF Time | [ctftime.org](http://ctftime.org/?fbclid=IwAR26fXW5aM0YTfSYOdVE34LJuQZnUQSJry54ORvkB5XZGAbi3_LdC-ACOaU) |
 | 스프링 캠프 | [springcamp.io/2019](https://www.springcamp.io/2019/) |


### PR DESCRIPTION
구글 해시 코드는 2023년을 끝으로 더 이상 열리지 않습니다.

* https://codingcompetitions.withgoogle.com/hashcode/