### PR TITLE
fix title

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@
   - 분류: `오프라인`, `대회`, `웹3`
   - 주최: Ludium
   - 접수: 08. 21(월) ~ 09. 23(수)
-- __[제1회 신약개발 AI 경진대회](https://festa.io/events/4031)__
+- __[Seoul iOS Meetup](https://festa.io/events/4031)__
   - 분류: `오프라인`, `iOS`
   - 주최: Seoul iOS Meetup
   - 접수: 09. 18(월) ~ 09. 25(월)


### PR DESCRIPTION
Seoul iOS Meetup 행사 데목이 '제1회 신약개발 AI 경진대회' 로 잘못 기재된 부분 수정.