### PR TITLE
docs: add Hugging Face KREW Hackathon 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,10 @@
   - 분류: `오프라인`, `무료`, `오픈소스`
   - 주최: 한국저작권위원회
   - 접수: 08. 16(수) ~ 11. 30(목)
+- __[Hugging Face KREW Hackathon 2023: 일상에서의 AI](https://pseudo-lab.github.io/huggingface-hackathon23/ko/)__
+  - 분류: `온라인`, `오프라인`, `무료`, `AI`, `오픈소스`
+  - 주최: Hugging Face KREW
+  - 접수: 10. 20(금) ~ 11. 10(금)
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@
   - 분류: `오프라인`, `무료`, `기술일반`
   - 주최: 부산광역시
   - 일시: 11. 08(수) ~ 11. 09(목)
+- __[Hugging Face KREW Hackathon 2023: 일상에서의 AI](https://pseudo-lab.github.io/huggingface-hackathon23/ko/)__
+  - 분류: `온라인`, `오프라인`, `무료`, `AI`, `오픈소스`
+  - 주최: Hugging Face KREW
+  - 접수: 10. 20(금) ~ 11. 10(금)
 - __[제 13회 소프트웨어 개발보안 컨퍼런스](https://onoffmix.com/event/286390)__
   - 분류: `온라인`, `오프라인`, `무료`, `보안`
   - 주최: 행전안전부
@@ -282,10 +286,6 @@
   - 분류: `오프라인`, `무료`, `오픈소스`
   - 주최: 한국저작권위원회
   - 접수: 08. 16(수) ~ 11. 30(목)
-- __[Hugging Face KREW Hackathon 2023: 일상에서의 AI](https://pseudo-lab.github.io/huggingface-hackathon23/ko/)__
-  - 분류: `온라인`, `오프라인`, `무료`, `AI`, `오픈소스`
-  - 주최: Hugging Face KREW
-  - 접수: 10. 20(금) ~ 11. 10(금)
 
 <br />
 


### PR DESCRIPTION
안녕하세요, **[가짜연구소(7th Pseudo Lab) 리서치팀](https://pseudo-lab.com/HuggingFace-KREW-26245cf06e5240d09973d8b4b4027a69)에서 활동 중인 [Hugging Face KREW Hackathon 2023](https://pseudo-lab.github.io/huggingface-hackathon23/ko/)** 운영진입니다 😄 

**Hugging Face KREW Hackathon 2023 행사를 Dev-Event에 추가 가능**한지 확인 부탁드리고자 PR를 남겼습니다.

국내 Hugging Face 커뮤니티 활성화 및 네트워킹을 목적으로 11월 10일까지 온라인 해커톤을 진행되며,  
[오프라인 세션](https://event-us.kr/huggingfacekrew/event/72612)은 11월 11일 [7th PseudoCon 행사]( https://event-us.kr/pseudolab/event/73265)에서 예정되어 있습니다.

해당 행사가 Dev-Event에 추가되어도 괜찮으신지 확인 부탁드립니다. 감사합니다. 