### PR TITLE
UbuCon Asia 2023 & Ubuntu Summit 2023 Recap Seminar 잘못된 URL 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@
   - 분류: `오프라인`, `유료`, `모임`
   - 주최: GDG Cloud Busan
   - 접수: 11. 16(목) ~ 12. 09(토)
-- __[UbuCon Asia 2023 & Ubuntu Summit 2023 Recap Seminar](https://festa.io/events/4360)__
+- __[UbuCon Asia 2023 & Ubuntu Summit 2023 Recap Seminar](https://festa.io/events/4378)__
   - 분류: `오프라인`, `무료`, `오픈소스`
   - 주최: 우분투한국커뮤니티
   - 접수: 11. 21(화) ~ 12. 09(토)


### PR DESCRIPTION
행사 참가 등록 링크가 잘못 들어가 있어 수정 하였습니다.