### PR TITLE
GDSC DevFest Campus URL 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@
   - 분류: `온라인`, `무료`, `교육`
   - 주최: 이스트소프트
   - 접수: 11. 20(월) ~ 12. 22(금)
-- __[GDSC DevFest Campus](https://festa.io/events/4368)__
+- __[GDSC DevFest Campus](https://festa.io/events/4397)__
   - 분류: `오프라인`, `무료`, `모임`
   - 주최: GDSC DevFest Campus
   - 접수: 11. 22(수) ~ 12. 23(금)


### PR DESCRIPTION
GDSC DevFest Campus 2023 행사에 대해,
현재 링크된 URL(https://festa.io/events/4368) 이 존재하지 않아 올바른 URL(https://festa.io/events/4397)로 수정합니다!