### PR TITLE
개발자 모임 NextJS Korea 오타 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@
 | React Korea | [facebook](https://www.facebook.com/groups/react.ko/) |
 | Vuejs Korea | [facebook](https://vuejs-kr.github.io/) |
 | Node.js Korea | [facebook](https://www.facebook.com/groups/nodejskr) |
-| NextJS Korea | [facebook](https://www.facebook.com/groups/nestjs-kr) |
+| NestJS Korea | [facebook](https://www.facebook.com/groups/nestjs-kr) |
 | OSXDev.org | [facebook](https://www.facebook.com/groups/osxdevorg/) |
 | GDG Korea WebTech | [facebook](https://www.facebook.com/groups/webTechKR/) |
 | KSUG - 한국 스프링 사용자 모임 | [facebook](https://www.ksug.org/) |


### PR DESCRIPTION
개발자 모임 - NextJS Korea 의 페이스북 링크가 NestJS Korea인데 모임 제목이 NextJS Korea로 잘못 표기되었습니다.
NextJS Korea 에서 NestJS Korea로 수정하였습니다!