### PR TITLE
WWDC24 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,8 +305,7 @@
   - 접수: 05. 07(화) ~ 06. 12(수)
 - __[I/O Extended Golang Korea 2024](https://festa.io/events/5181)__
   - 분류: `오프라인(서울 강남)`, `유료`, `AI`
-  - 주최: 
-Golang Korea
+  - 주최: Golang Korea
   - 접수: 05. 07(화) ~ 06. 12(수)
 - __[Google Cloud Summit Seoul ’24](https://cloudonair.withgoogle.com/events/summit-seoul-2024)__
   - 분류: `온라인`, `무료`, `클라우드`

--- a/README.md
+++ b/README.md
@@ -291,6 +291,10 @@
   - 분류: `온라인`, `무료`, `기술일반`, `대회`
   - 주최: 과학기술정보통신부
   - 접수: 05. 07(화) ~ 06. 07(금)
+- __[WWDC24](https://developer.apple.com/wwdc24/)__
+  - 분류: `온라인`, `무료`, `iOS`
+  - 주최: Apple
+  - 접수: 03. 26(화) ~ 06. 10(월)
 - __[DroidKnights 2024](https://festa.io/events/4990)__
   - 분류: `오프라인(서울 강남)`, `유료`, `안드로이드`
   - 주최: DroidKnights Community


### PR DESCRIPTION
2024년 06월에 애플에서 개최하는 WWDC24가 빠져 있어서 추가했습니다.

또 Golang 컨퍼런스 부분에서 불필요한 개행이 있어 제거했습니다.