### PR TITLE
docs: 엘리스 도메인 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@
 | 모두의 연구소 | [Homepage](https://modulabs.co.kr/) |
 | CCCR 아카데미 | [Homepage](https://www.cccr-edu.or.kr/main/index.jsp) |
 | 인공지능혁신학교 AIFFEL  | [Homepage](https://aiffel.io/) |
-| 엘리스 | [Homepage](https://elice.io/home) |
+| 엘리스 | [Homepage](https://elice.io/) |
 | 알고리즘 캠프 | [Homepage](https://algorithmcamp.oopy.io/) |
 | SW사관학교 정글(카이스트) | [Homepage](https://swjungle.net/) |
 | Apple Developer Academy @ POSTECH |[Homepage](https://developeracademy.postech.ac.kr/)|


### PR DESCRIPTION
- 기존 엘리스 링크 접속 시 500 에러가 발생합니다.
- 올바른 엘리스 링크로 수정하였습니다.