### PR TITLE
add Build with AI: GDG StartUP Lab 행사 및 campus korea chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@
   - 분류: `오프라인(경기 성남)`, `무료`, `기술일반`
   - 주최: 과학기술정보통신부
   - 접수: 02. 25(화) ~ 04. 20(일)
+- __[Build with AI: GDG StartUP Lab](https://event-us.kr/gdgcampuskorea/event/100657?utm_source=eventus&utm_medium=organic&utm_campaign=search-result&utm_term=Build+with+AI%3A+GDG+StartUP+Lab)__
+  - 분류: `온라인`, `유료`, `기술일반`
+  - 주최: GDG Campus Korea
+  - 접수: 03. 26(수) ~ 04. 20(일)
 - __[AWSKRUG #magok 마곡 소모임](https://www.meetup.com/awskrug/events/307051845/)__
   - 분류: `오프라인(서울 마곡)`, `유료`, `AI`
   - 주최: AWSKRUG
@@ -462,6 +466,7 @@
 | GDG Golang Korea | [facebook](https://www.facebook.com/gdggo/) |
 | GDG Incheon & Songdo | [homepage](http://gdgincheon.com/), [instagram](https://www.instagram.com/gdg_songdo/), [facebook](https://www.facebook.com/groups/gdgsongdo/) |
 | Data Scientist Meetup in Seoul |[meetup](https://www.meetup.com/ko-KR/Data-Scientist-Meetup-in-Seoul/) |
+| GDG Campus Korea | [homepage](https://gdg.community.dev/gdg-campus-korea/), [Instagram](https://www.instagram.com/gdg.campuskorea) |
 | IT인프라 엔지니어 그룹 | [facebook](https://www.facebook.com/groups/InfraEngineer/) |
 | GDG DevFest Seoul | [facebook](https://www.facebook.com/devfest.seoul.2019/) |
 | OSS 개발자 포럼 | [facebook](https://www.facebook.com/groups/ossdevforum) |

--- a/README.md
+++ b/README.md
@@ -168,10 +168,6 @@
   - 분류: `오프라인(경기 성남)`, `무료`, `기술일반`
   - 주최: 과학기술정보통신부
   - 접수: 02. 25(화) ~ 04. 20(일)
-- __[Build with AI: GDG StartUP Lab](https://event-us.kr/gdgcampuskorea/event/100657?utm_source=eventus&utm_medium=organic&utm_campaign=search-result&utm_term=Build+with+AI%3A+GDG+StartUP+Lab)__
-  - 분류: `온라인`, `유료`, `기술일반`
-  - 주최: GDG Campus Korea
-  - 접수: 03. 26(수) ~ 04. 20(일)
 - __[AWSKRUG #magok 마곡 소모임](https://www.meetup.com/awskrug/events/307051845/)__
   - 분류: `오프라인(서울 마곡)`, `유료`, `AI`
   - 주최: AWSKRUG
@@ -204,6 +200,10 @@
   - 분류: `오프라인`, `무료`, `교육`
   - 주최: 네이버 커넥트재단
   - 접수: 02. 20(목) ~ 04. 30(수)
+- __[Build with AI: GDG StartUP Lab](https://event-us.kr/gdgcampuskorea/event/100657?utm_source=eventus&utm_medium=organic&utm_campaign=search-result&utm_term=Build+with+AI%3A+GDG+StartUP+Lab)__
+  - 분류: `온라인`, `유료`, `기술일반`
+  - 주최: GDG Campus Korea
+  - 접수: 03. 26(수) ~ 04. 20(일)
 
 <br />
 
@@ -450,6 +450,7 @@
 | 청년취업사관학교(SeSAC) | [Homepage](https://sesac.seoul.kr/) |
 | KT AIVLE School | [Homepage](https://aivle.kt.co.kr/home/main/indexMain) |
 | 프로그래머스 데브코스 | [Homepage](https://school.programmers.co.kr/learn/KDT) |
+| 카카오테크 부트캠프 | [Homepage](https://ktb.goorm.io/) |
 
 > :arrow_double_up: [Top](#지난-행사-기록)
 
@@ -466,7 +467,6 @@
 | GDG Golang Korea | [facebook](https://www.facebook.com/gdggo/) |
 | GDG Incheon & Songdo | [homepage](http://gdgincheon.com/), [instagram](https://www.instagram.com/gdg_songdo/), [facebook](https://www.facebook.com/groups/gdgsongdo/) |
 | Data Scientist Meetup in Seoul |[meetup](https://www.meetup.com/ko-KR/Data-Scientist-Meetup-in-Seoul/) |
-| GDG Campus Korea | [homepage](https://gdg.community.dev/gdg-campus-korea/), [Instagram](https://www.instagram.com/gdg.campuskorea) |
 | IT인프라 엔지니어 그룹 | [facebook](https://www.facebook.com/groups/InfraEngineer/) |
 | GDG DevFest Seoul | [facebook](https://www.facebook.com/devfest.seoul.2019/) |
 | OSS 개발자 포럼 | [facebook](https://www.facebook.com/groups/ossdevforum) |
@@ -518,6 +518,7 @@
 | AsyncSwift | [discord](https://discord.gg/VeERbm3VKC), [homepage](https://asyncswift.org/) |
 | C++ Korea | [discord](https://discord.gg/87SNegGZue), [facebook](https://fb.com/groups/cppkorea/), [Github](https://github.com/CppKorea) |
 | Datadog 한국 사용자 모임 | [homepage](https://datadogkrug.vercel.app) |
+| GDG Campus Korea | [homepage](https://gdg.community.dev/gdg-campus-korea/), [Instagram](https://www.instagram.com/gdg.campuskorea) |
 
 > :arrow_double_up: [Top](#지난-행사-기록)
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@
   - 분류: `오프라인(경기 성남)`, `무료`, `기술일반`
   - 주최: 과학기술정보통신부
   - 접수: 02. 25(화) ~ 04. 20(일)
+- __[Build with AI: GDG StartUP Lab](https://event-us.kr/gdgcampuskorea/event/100657?utm_source=eventus&utm_medium=organic&utm_campaign=search-result&utm_term=Build+with+AI%3A+GDG+StartUP+Lab)__
+  - 분류: `온라인`, `유료`, `기술일반`
+  - 주최: GDG Campus Korea
+  - 접수: 03. 26(수) ~ 04. 20(일)
 - __[AWSKRUG #magok 마곡 소모임](https://www.meetup.com/awskrug/events/307051845/)__
   - 분류: `오프라인(서울 마곡)`, `유료`, `AI`
   - 주최: AWSKRUG
@@ -200,10 +204,6 @@
   - 분류: `오프라인`, `무료`, `교육`
   - 주최: 네이버 커넥트재단
   - 접수: 02. 20(목) ~ 04. 30(수)
-- __[Build with AI: GDG StartUP Lab](https://event-us.kr/gdgcampuskorea/event/100657?utm_source=eventus&utm_medium=organic&utm_campaign=search-result&utm_term=Build+with+AI%3A+GDG+StartUP+Lab)__
-  - 분류: `온라인`, `유료`, `기술일반`
-  - 주최: GDG Campus Korea
-  - 접수: 03. 26(수) ~ 04. 20(일)
 
 <br />
 


### PR DESCRIPTION
안녕하세요!

4월 26일(토)에 GDG Campus Korea Chapter에서 행사가 진행되어 행사랑 저희 Chapter 링크 추가했습니다!

추가로 개발 교육 기관 목록에 '카카오테크 부트캠프'를 추가했습니다.