### PR TITLE
docs: 2025 dnd 해커톤 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@
   - 분류: `온라인`, `무료`, `대회`
   - 주최: Codetree, Powered by AWS Korea
   - 접수: 04. 07(월) ~ 05. 11(일)
+- __[DND 해커톤 :: 퍼즐처럼 맞춰가는 1박 2일의 즐거움!](https://event-us.kr/dndacademy/event/101920?utm_source=eventus&utm_medium=organic&utm_campaign=search-result)__
+  - 분류: `오프라인(서울 마포구)`, `유료`, `대회`
+  - 주최: DND
+  - 접수: 04. 23(수) ~ 05. 11(일)
 - __[개발자를 위한 고급 프롬프트 엔지니어링](https://biz.modulabs.co.kr/event/235)__
   - 분류: `오프라인(서울 강남)`, `무료`, `AI`
   - 주최: 모두의 연구소

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@
   - 주최: Codetree, Powered by AWS Korea
   - 접수: 04. 07(월) ~ 05. 11(일)
 - __[DND 해커톤 :: 퍼즐처럼 맞춰가는 1박 2일의 즐거움!](https://event-us.kr/dndacademy/event/101920?utm_source=eventus&utm_medium=organic&utm_campaign=search-result)__
-  - 분류: `오프라인(서울 마포구)`, `유료`, `대회`
+  - 분류: `오프라인(서울 마포구)`, `유료`, `해커톤`
   - 주최: DND
   - 접수: 04. 23(수) ~ 05. 11(일)
 - __[개발자를 위한 고급 프롬프트 엔지니어링](https://biz.modulabs.co.kr/event/235)__

--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@
   - 분류: `온라인`, `무료`, `대회`
   - 주최: Codetree, Powered by AWS Korea
   - 접수: 04. 07(월) ~ 05. 11(일)
-- __[DND 해커톤 :: 퍼즐처럼 맞춰가는 1박 2일의 즐거움!](https://event-us.kr/dndacademy/event/101920?utm_source=eventus&utm_medium=organic&utm_campaign=search-result)__
-  - 분류: `오프라인(서울 마포구)`, `유료`, `해커톤`
+- __[DND 해커톤 :: 퍼즐처럼 맞춰가는 1박 2일의 즐거움!](https://event-us.kr/dndacademy/event/101920)__
+  - 분류: `오프라인(서울 마포구)`, `유료`, `대회`
   - 주최: DND
   - 접수: 04. 23(수) ~ 05. 11(일)
 - __[개발자를 위한 고급 프롬프트 엔지니어링](https://biz.modulabs.co.kr/event/235)__


### PR DESCRIPTION
안녕하세요, DND 해커톤 일정이 있어 공유드립니다 🥸

- __[DND 해커톤 :: 퍼즐처럼 맞춰가는 1박 2일의 즐거움!](https://event-us.kr/dndacademy/event/101920?utm_source=eventus&utm_medium=organic&utm_campaign=search-result)__
  - 분류: `오프라인(서울 마포구)`, `유료`, `해커톤`
  - 주최: DND
  - 접수: 04. 23(수) ~ 05. 11(일)