### PR TITLE
docs: K-DEVCON 2025 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,14 +201,11 @@
 <br />
 
 ## 25년 11월
-- __[K-DEVCON 2025](https://www.ticketa.co/events/33)__
-  - 분류: `오프라인(서울 광화문)`, `유료`, `기술일반`
-  - 주최: K-DEVCON 
-  - 일시: 11. 01(토)
 - __[FOSS for All Conference 2025](https://2025.fossforall.org/)__
   - 분류: `오프라인(광운대학교)`, `유료`, `기술일반`
   - 주최: FOSS for All 
   - 접수: 08. 19(화) ~ 11. 07(금)
+  
 - __[GopherCon Korea 2025](https://www.ticketa.co/events/25)__
   - 분류: `오프라인`, `유료`, `기술일반`
   - 주최: Golang Korea


### PR DESCRIPTION
안녕하세요!

K-DEVCON에서 'K-DEVCON 2025' 행사를 개최합니다.

일시 : 2025.11.01 (토) 13:00 ~ 18:00
장소 : 한국 마이크로소프트 13층 (광화문)
접수 : 09.25(목) ~ 11.01(토)
이 행사에 대해 추가했습니다.

감사합니다!