### PR TITLE
Add DDD Seoul Event

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@
   - 주최: 크래프톤 정글
   - 접수: 11. 11(화) ~ 12. 04(목)
 - __[DDD Seoul 2025](https://www.ticketa.co/events/46)__
-  - 분류: `오프라인(서울 광화문)`, `유료`, `Microsoft`, `AI`, `기술일반`
+  - 분류: `오프라인(서울 광화문)`, `유료`, `AI`, `기술일반`
   - 주최: DDD Seoul 커뮤니티
   - 접수: 11. 18(화) ~ 12. 04(목)
 - __[DEVFEST INCHEON 2025](https://www.ticketa.co/events/40)__


### PR DESCRIPTION
안녕하세요~ 
12월 5일 진행하는 DDD 서울 추가 요청드립니다.
Microsoft 기술 기반 커뮤니티 행사입니다.

- __[DDD Seoul 2025](https://www.ticketa.co/events/46)__
  - 분류: `오프라인(서울 광화문)`, `유료`, `Microsoft`, `AI`, `기술일반`
  - 주최: DDD Seoul 커뮤니티
  - 접수: 11. 18(화) ~ 12. 04(목)

머지 해주시면 더 많은 분들께 이 행사를 소개할 수 있습니다.
감사합니다.