### PR TITLE
docs: Add Dev Korea #5 event details

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@
   - 주최: 패스트캠퍼스
   - 접수: 11. 19(수) ~ 12. 09(화)
 - __[Dev Korea #5 with Supabase](https://dev-korea.com/events/dev-korea-5-december-2025)__
-  - 분류: `오프라인`, `무료`, `Supabase`
+  - 분류: `오프라인`, `무료`, `기술일반`
   - 주최: Dev Korea
   - 접수: 11. 19(수) ~ 12. 10(수)
 - __[모두콘 2025](https://modulabs.co.kr/community/momos/424)__


### PR DESCRIPTION
Hey there!

Adding a new event we will be hosting soon! 

__[Dev Korea #5 with Supabase](https://dev-korea.com/events/dev-korea-5-december-2025)__
  - 분류: `오프라인`, `무료`, `Supabase`
  - 주최: Dev Korea
  - 접수: 11. 19(수) ~ 12. 10(수)

Thank you :)