### PR TITLE
fix: README 테이블 렌더링 복구

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@
           <!-- <td> 종료 행사 </td> -->
           <td>2026년</td>
           <td>
-            <a href="./end_event/2026/26_01.md"> 01월 </a>
+            <a href="./end_event/2026/26_01.md"> 01월 </a>,
             <a href="./end_event/2026/26_02.md"> 02월 </a>
           </td>
         </tr>


### PR DESCRIPTION
마크다운의 Table 에선 공백 라인이 허용되지 않는 것 같습니다. 이 PR 의 패치 전 후 사진을 첨부합니다.

Current version:
<img width="2010" height="1138" alt="Screenshot 2026-01-25 at 20 44 34" src="https://github.com/user-attachments/assets/526b2af3-3143-4c06-92d3-95e498083df2" />

This patch version:
<img width="1826" height="704" alt="Screenshot 2026-01-25 at 20 44 51" src="https://github.com/user-attachments/assets/2e73d768-d3cf-4ba6-b977-5c2f0a542ac8" />
