### PR TITLE
docs: add new Dev Korea event

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@
   - 분류: `오프라인(서울 코엑스)`, `유료`, `기술일반`
   - 주최: 과학기술정보통신부
   - 일시: 02. 06(금) ~ 04. 21(화)
+- __[Design Korea #0 with Figma](https://dev-korea.com/events/design-korea-0-april-2026)__
+  - 분류: `오프라인(서울)`, `무료`, `모임`, `디자인`, `UI/UX`
+  - 주최: Dev Korea
+  - 접수: 03. 20(금) ~ 04. 23(목) 19:00
 - __[삼성 청년 SW / AI 아카데미 SSAFY 14기 모집](https://www.ssafy.com/ksp/jsp/swp/apply/swpApplyProcess.jsp?_gl=1*1rntetw*_gcl_au*MjkyMDA5OTQyLjE3NzM2NjUyODE.)__
   - 분류: `오프라인`, `무료`, `교육`
   - 주최: 싸피

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@
   - 주최: 과학기술정보통신부
   - 일시: 02. 06(금) ~ 04. 21(화)
 - __[Design Korea #0 with Figma](https://dev-korea.com/events/design-korea-0-april-2026)__
-  - 분류: `오프라인(서울)`, `무료`, `모임`, `디자인`, `UI/UX`
+  - 분류: `오프라인(서울)`, `무료`, `기술일반`
   - 주최: Dev Korea
   - 접수: 03. 20(금) ~ 04. 23(목) 19:00
 - __[삼성 청년 SW / AI 아카데미 SSAFY 14기 모집](https://www.ssafy.com/ksp/jsp/swp/apply/swpApplyProcess.jsp?_gl=1*1rntetw*_gcl_au*MjkyMDA5OTQyLjE3NzM2NjUyODE.)__


### PR DESCRIPTION
Hi there!

Adding a new event we are organizing:

- __[Design Korea #0 with Figma](https://dev-korea.com/events/design-korea-0-april-2026)__
  - 분류: `오프라인(서울)`, `무료`, `모임`, `디자인`, `UI/UX`
  - 주최: Dev Korea
  - 접수: 03. 20(금) ~ 04. 23(목) 19:00

Thank you 😊