### PR TITLE
docs: DND 15기 일정 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@
   - 분류: `온라인`, `무료`, `대회`, `AI`
   - 주최: 과학기술정보통신부
   - 접수: 05. 12(화) ~ 06. 14(일) 23:59
+- __[DND 15기 모집](https://dnd.ac/)__
+  - 분류: `온/오프라인`, `무료`, `동아리`
+  - 주최: DND
+  - 접수: 06. 01(월) ~ 06. 14(일) 23:59
 - __[The Turing Test Hackathon 2026 — Phase 2. AI Awakening Hackathon](https://dorahacks.io/hackathon/mantleturingtesthackathon2026/detail)__
   - 분류: `온라인`, `무료`, `대회`, `블록체인`, `AI`
   - 주최: Mantle / Bybit / Byreal / BGA
@@ -399,7 +403,7 @@
 | YAPP | 대학생 연합 기업형 IT 동아리                             | [yapp.co.kr](http://yapp.co.kr/), [instagram](https://www.instagram.com/about.yapp/) |
 | Mash-Up | 성장의 즐거움을 아는 친구들                               | [mash-up.kr](https://www.mash-up.kr/), [facebook](https://www.facebook.com/mashupgroup/) |
 | AUSG | AWS 대학생 그룹                                    | [ausg.me](https://ausg.me/) |
-| DND | 서울거주 현직자들의 기술공유와 프로젝트를 진행하는 비영리단체             | [dnd.ac](https://dnd.ac/) |
+| DND | 개발자와 디자이너라면 누구나 참여할 수 있는 IT 비영리단체                    | [dnd.ac](https://dnd.ac/) |
 | SOPT | 대학생 연합 IT벤처 창업 동아리                            | [sopt.org](https://www.sopt.org/) |
 | 멋쟁이사자처럼 | 대학생 연합 동아리                                    | [likelion.net](https://likelion.net/), [facebook](https://www.facebook.com/likelion.net/) |
 | Google Developer Student <br /> Clubs Korea | Google Developers 에서 후원하는 대학생 개발자 동아리         | [DSC](https://developers.google.com/community/dsc), [DSC Korea](https://sites.google.com/view/dsckr/home), [facebook](https://www.facebook.com/dsckorea) |


### PR DESCRIPTION
DND 15기 모집을 6월 섹션에 추가하고, `개발자 동아리` 표의 DND 소개 문구를 현재 단체 정체성에 맞게 수정합니다.

## 추가한 행사
  
>[DND 15기 모집](https://dnd.ac/)
>
>분류: 온/오프라인, 무료, 동아리
>주최: DND
>접수: 06. 01(월) ~ 06. 14(일) 23:59

각 항목은 기존 6월 섹션의 마감일 순서(`06.14`)에 맞춰 삽입했고,
README 컨벤션(분류·주최·접수)을 유지했습니다.

## 동아리 소개 문구 수정

`개발자 동아리` 표의 DND 설명을 다음과 같이 변경했습니다.

- Before: `서울 거주 현직자들의 기술 공유와 프로젝트를 진행하는 비영리단체`
- After: `개발자와 디자이너라면 누구나 참여할 수 있는 IT 비영리단체`

DND는 _"서울에 편중되어 있는 기술 공유와 세미나를 지방에서도 나누고자 2019년 설립"_ 된 단체로, 기존 "서울 거주" 표현은 단체의 실제 미션과 정반대 의미를 전달하고 있었습니다.

위 두 개 부분 수정하여 공유드립니다.

감사합니다.