### PR TITLE
Adding Dev Korea 12 and Qwen Meetup Seoul 4 (Dev Korea 13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@
   - 분류: `오프라인`, `무료`, `교육`, `AI`
   - 주최: KT
   - 접수: 07. 07(화) ~ 08. 10(월)
+- __[Dev Korea #12](https://dev-korea.com/events/dev-korea-12-august-2026)__
+  - 분류: `오프라인(서울 마포구)`, `무료`, `모임`, `기술일반`
+  - 주최: Dev Korea
+  - 접수: 07. 20(월) ~ 08. 11(화)
 - __[멀티 에이전트 워크샵 with GitHub Copilot](https://ticketa.co/event/c99wxzdg)__
   - 분류: `오프라인(서울 종로구)`, `유료`, `세미나`, `AI`, `클라우드`
   - 주최: Microsoft 커뮤니티 이벤트

--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@
   - 분류: `오프라인`, `유료`, `기술일반`
   - 주최: 파이콘 코리아
   - 접수: 08. 15(토) ~ 08. 17(월)
+- __[Qwen Meetup Seoul #4 (Dev Korea #13)](https://dev-korea.com/events/dev-korea-13-august-2026)__
+  - 분류: `오프라인(서울 강남구)`, `무료`, `모임`, `AI`
+  - 주최: Dev Korea / Qwen
+  - 접수: 07. 27(월) ~ 08. 19(수)
 - __[2026 금융권 공동채용 박람회](https://financejobfair.co.kr/info/info_01)__
   - 분류: `오프라인(서울 중구)`, `무료`, `세미나`
   - 주최: 은행연합회 등 금융권 82개사


### PR DESCRIPTION
Hi there!

Adding 2 new events we are organizing:

- __[Dev Korea #12](https://dev-korea.com/events/dev-korea-12-august-2026)__
  - 분류: `오프라인(서울 마포구)`, `무료`, `모임`, `기술일반`
  - 주최: Dev Korea
  - 접수: 07. 20(월) ~ 08. 11(화)
- __[Qwen Meetup Seoul #4 (Dev Korea #13)](https://dev-korea.com/events/dev-korea-13-august-2026)__
  - 분류: `오프라인(서울 강남구)`, `무료`, `모임`, `AI`
  - 주최: Dev Korea / Qwen
  - 접수: 07. 27(월) ~ 08. 19(수)

Thank you 😊