### PR TITLE
26년 8월 행사 등록

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,19 @@
   - 접수: 05. 11(월) ~ 08. 31(월)
 
 <br />
+- __[SpaceX 밋업: Starlink와 xAI까지 함께 보는 우주 인프라의 미래](https://www.rocketpunch.com/event/evx8Yo8jus)__
+  - 분류: `오프라인`, `무료`, `세미나`, `AI`
+  - 주최: 내러티브
+  - 일시: 08. 12(수)
+- __[Open AGI 빌더스 데이 at KDD](https://www.rocketpunch.com/event/8A2KPAjh3O)__
+  - 분류: `오프라인`, `무료`, `모임`, `블록체인`, `AI`
+  - 주최: Sentient Labs
+  - 일시: 08. 13(목)
+- __[[용인시산업진흥원] 2026년 용인 오픈이노베이션 교류회 3회차(바이오·헬스케어)](https://www.rocketpunch.com/event/dorjqKAbk8)__
+  - 분류: `오프라인`, `무료`, `세미나`, `AI`
+  - 주최: 주식회사 알파브라더스
+  - 일시: 08. 19(수)
+
 
 ## `26년 09월`
 - __[MongoDB .local Seoul](https://www.mongodb.com/ko-kr/events/mongodb-local/seoul)__


### PR DESCRIPTION
로켓펀치 이벤트 페이지에서 신규 개발자 행사 3건을 등록합니다.

## 추가한 행사

- SpaceX 밋업: Starlink와 xAI까지 함께 보는 우주 인프라의 미래
  - https://www.rocketpunch.com/event/evx8Yo8jus
- Open AGI 빌더스 데이 at KDD
  - https://www.rocketpunch.com/event/8A2KPAjh3O
- [용인시산업진흥원] 2026년 용인 오픈이노베이션 교류회 3회차(바이오·헬스케어)
  - https://www.rocketpunch.com/event/dorjqKAbk8

각 항목은 기존 컨벤션(분류·주최·일시)에 맞춰 월별 섹션에 삽입했습니다.
자동화 스크립트(`~/.hermes/scripts/dev_event_weekly_pr.py`)로 생성된 PR입니다.